### PR TITLE
feat: add new feature to jump to MRU folders

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,15 @@ pub fn build_app() -> App<'static> {
                         .help("Recursively removes."),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("jump")
+                .about("List most recently visited folders.")
+                .arg(
+                    Arg::with_name("number")
+                        .empty_values(false)
+                        .help("Jump to n-th most recently visited folder"),
+                ),
+        )
         .arg(
             Arg::with_name("name")
                 .empty_values(true)

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,9 +10,10 @@ use dirs;
 
 use crate::pretty_print;
 
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct GotoFile {
-    pub path: String,
     pub count: u32,
+    pub path: String,
 }
 
 // reads k,v pairs from db, returning a hmap
@@ -71,7 +72,7 @@ pub fn update_count(mut hm: HashMap<String, GotoFile>, key: &String) {
     for (_, val) in hm.iter_mut() {
         if val.path == *key {
             val.count += 1;
-            write_db(hm);
+            write_db(hm); // ignore errors, we can skip updates
             break;
         }
     }
@@ -90,5 +91,17 @@ pub fn list() -> Result<()> {
 
     println!("======= Current Indexed Directories (alias highlighted) =======");
     v.sort_by(|a, b| a.1.path.cmp(&b.1.path));
-    pretty_print::pretty_print(&v)
+    pretty_print::pretty_print_tree(&v)
+}
+
+pub fn list_jumpsites(hm: HashMap<String, GotoFile>) -> Vec<GotoFile> {
+    let mut vec: Vec<GotoFile> = Vec::new();
+    for (_, val) in hm.iter() {
+        if val.count > 0 {
+            vec.push(val.clone());
+        }
+    }
+    vec.sort();
+    vec.reverse();
+    vec
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -17,11 +17,18 @@ _gt() {{
     fi
 }}
 gt() {{
-    result="$(goto-rs "$@")" || return "$?"
-    if [ -d "$result" ]; then
-            _gt "$result" || return "$?"
-        elif [ -n "$result" ]; then
-            echo "$result"
+    if [[ -z $@ ]]; then
+        goto-rs jump
+        read jump_num
+        result=$(goto-rs jump "$jump_num")
+        cd $result
+    else
+        result="$(goto-rs "$@")" || return "$?"
+        if [ -d "$result" ]; then
+                _gt "$result" || return "$?"
+            elif [ -n "$result" ]; then
+                echo "$result"
+        fi
     fi
 }}
 "#,

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,13 +50,34 @@ fn run() -> Result<()> {
         return indexer::prune();
     }
 
+    if let Some(subcmd) = matches.subcommand_matches("jump") {
+        return db::read_db()
+            .map(|folders| {
+                let jumpsites = db::list_jumpsites(folders);
+                match subcmd.occurrences_of("number") {
+                    1 => {
+                        let idx = subcmd
+                            .get_one::<String>("number")
+                            .unwrap()
+                            .trim()
+                            .parse::<usize>()
+                            .unwrap();
+                        let site: &db::GotoFile = &jumpsites[idx - 1];
+                        switch::switch_to(&site.path, true)
+                    }
+                    _ => pretty_print::pretty_print_jumpsites(&jumpsites),
+                }
+            })
+            .and_then(|f| f);
+    }
+
     if matches.subcommand_matches("init").is_some() {
         init::init();
         return Ok(());
     }
 
     match matches.occurrences_of("name") {
-        1 => switch::switch_to(matches.value_of("name").unwrap()),
+        1 => switch::switch_to(matches.value_of("name").unwrap(), false),
         _ => Err(anyhow!("Incorrect number of arguments.")),
     }
 }

--- a/src/pretty_print.rs
+++ b/src/pretty_print.rs
@@ -4,7 +4,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::db;
 
-pub fn pretty_print(db: &[(&String, &db::GotoFile)]) -> Result<()> {
+pub fn pretty_print_tree(db: &[(&String, &db::GotoFile)]) -> Result<()> {
     let mut dummy = Node {
         next_level: Vec::new(),
         name: "".to_string(),
@@ -37,6 +37,22 @@ pub fn pretty_print(db: &[(&String, &db::GotoFile)]) -> Result<()> {
     // dummy has no prefix and no sibling nodes,
     // hence we seed with empty string and 0.
     dummy.prettyprint("".to_string(), 0)
+}
+
+pub fn pretty_print_jumpsites(sites: &Vec<db::GotoFile>) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(&mut stdout, "Listing all jump sites")?;
+    writeln!(&mut stdout)?;
+
+    let mut iter = sites.iter().enumerate();
+    while let Some((i, site)) = iter.next() {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
+        write!(&mut stdout, "[{}]", i + 1)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+        writeln!(&mut stdout, " {}", &site.path)?;
+    }
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -6,19 +6,22 @@ use anyhow::{anyhow, Result};
 
 // switch_to writes a single file path to stdout which will be
 // picked up by the bash command to `cd` to.
-pub fn switch_to(k: &str) -> Result<()> {
+pub fn switch_to(k: &str, exact: bool) -> Result<()> {
     let db = db::read_db()?;
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    let result = match db.get(k) {
-        Some(v) => Ok(v.path.clone()),
-        None => match fuzzy_lookup(&db, k) {
-            None => Err(anyhow!(format!(
-                "No such alias: {}, try using the `ls` command to list the aliases.",
-                k
-            ))),
-            Some(fk) => Ok(fk.clone()),
+    let result = match exact {
+        true => Ok(k.to_string()),
+        false => match db.get(k) {
+            Some(v) => Ok(v.path.clone()),
+            None => match fuzzy_lookup(&db, k) {
+                None => Err(anyhow!(format!(
+                    "No such alias: {}, try using the `ls` command to list the aliases.",
+                    k
+                ))),
+                Some(fk) => Ok(fk.clone()),
+            },
         },
     };
 


### PR DESCRIPTION
Implements #36 

Local testing steps
1. `cargo build`
2. `sudo cp target/debug/goto-rs /usr/local/bin/goto-rs`
3. `source ~/.zshrc`

```
oto on  jump-feature is 📦 vgoto-rs@0.3.0 via 🦀 v1.67.0 took 3s 
➜ gt
Listing all jump sites

[1] /Users/sylvester/aa/hyper
[2] /Users/sylvester/goto
[3] /Users/sylvester/go/src/device
[4] /Users/sylvester/go/src/playback
3

device on  master via 🐹 v1.17.3 took 2s 
➜ 

```