### PR TITLE
Improve search list: sorted and longer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use itertools::Itertools;
 use std::process;
 
 use inquire::Select;
@@ -48,11 +49,17 @@ fn run() -> Result<()> {
 
         Some(("search", _)) => {
             let jumpsites = match db::read_db() {
-                Ok(hash) => hash.values().map(|g| g.path.clone()).collect(),
+                Ok(hash) => hash
+                    .values()
+                    .sorted_by(|a, b| Ord::cmp(&b.count, &a.count))
+                    .map(|g| g.path.clone())
+                    .collect(),
                 Err(_) => vec![],
             };
 
-            let site = Select::new("Jump to:", jumpsites).prompt()?;
+            let site = Select::new("Jump to:", jumpsites)
+                .with_page_size(20)
+                .prompt()?;
 
             switch::switch_to(&site, true)
         }


### PR DESCRIPTION
The default size of 7 is too small. 20 would probably work better. In the future, this could be made customizable but if the fuzzy search is good enough, you don't need to eyeball too much (though 7 just feels too short).

Also, sorting it by most frequently accessed folder. 